### PR TITLE
[Bug Fix] Weird behaviour around applying mods

### DIFF
--- a/HON Mod Manager/HON Mod Manager.csproj
+++ b/HON Mod Manager/HON Mod Manager.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net461</TargetFramework>
 		<OutputType>WinExe</OutputType>
 		<NoStandardLibraries>false</NoStandardLibraries>
 		<AssemblyName>HoN_ModMan</AssemblyName>
@@ -12,18 +11,19 @@
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<UseWindowsForms>true</UseWindowsForms>
 		<ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+		<TargetFramework>net6.0-windows</TargetFramework>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<UseVSHostingProcess>false</UseVSHostingProcess>
 	</PropertyGroup>
 	<ItemGroup>
-		<Reference Include="Ionic.Zip.Reduced, Version=1.8.4.23, Culture=neutral, processorArchitecture=MSIL" />
-	</ItemGroup>
-	<ItemGroup>
 		<Content Include="Resources\disabled.png" />
 		<Content Include="Resources\HoN_ModMan.ico" />
 		<Content Include="Resources\Ionic.Zip.Reduced.dll" />
 		<Content Include="Resources\updating.png" />
+	</ItemGroup>
+	<ItemGroup>
+	  <PackageReference Include="DotNetZip" Version="1.16.0" />
 	</ItemGroup>
 	<ProjectExtensions>
 		<VisualStudio AllowExistingFolder="true" />

--- a/HON Mod Manager/HON Mod Manager.csproj
+++ b/HON Mod Manager/HON Mod Manager.csproj
@@ -25,9 +25,6 @@
 		<Content Include="Resources\Ionic.Zip.Reduced.dll" />
 		<Content Include="Resources\updating.png" />
 	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-	</ItemGroup>
 	<ProjectExtensions>
 		<VisualStudio AllowExistingFolder="true" />
 	</ProjectExtensions>

--- a/HON Mod Manager/MainForm.cs
+++ b/HON Mod Manager/MainForm.cs
@@ -1484,7 +1484,7 @@ namespace CS_ModMan
         private void OpenModFolderToolStripMenuItem_Click(object sender, EventArgs e)
         {
             ForgetAllZIPs();
-            Process.Start(Path.Combine(GameHelper.ModsDir, "mods"));
+            Process.Start(Environment.GetEnvironmentVariable("WINDIR") + @"\explorer.exe", Path.Combine(GameHelper.ModsDir, "mods"));
         }
 
         private void ListToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1736,7 +1736,7 @@ namespace CS_ModMan
             var tPath = Path.Combine(GameHelper.ModsDir, "mods");
             if (!Directory.Exists(tPath) && Directory.Exists(GameHelper.ModsDir))
                 Directory.CreateDirectory(tPath);
-
+            
             if (Directory.Exists(tPath))
                 foreach (var tFile in Directory.GetFiles(tPath, "*.honmod"))
                     try
@@ -2752,7 +2752,7 @@ namespace CS_ModMan
                 foreach (var File in OutFiles)
                 {
                     File.Value.Seek(0, SeekOrigin.Begin);
-                    OutFile.AddEntry(File.Key, null, File.Value);
+                    OutFile.AddEntry(File.Key, null, Encoding.UTF8);
                 }
 
                 OutFile.Comment = CommentString;

--- a/HON Mod Manager/MainForm.cs
+++ b/HON Mod Manager/MainForm.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Windows.Forms;
@@ -2152,34 +2153,7 @@ namespace CS_ModMan
             myStatusStrip.Refresh();
 
             //create ourselves a list of mods to apply, and order the mods according to set requirements
-            var ModList = new List<Modification>();
-            if (SelectedMods == null || SelectedMods.Count == 0)
-            {
-                foreach (var tMod in m_mods)
-                    if (tMod.Enabled)
-                        ModList.Add(tMod);
-            }
-            else
-            {
-                foreach (var SelectedMod in SelectedMods)
-                {
-                    var Found = false;
-                    foreach (var tMod in m_mods)
-                        if (tMod.FixedName == SelectedMod)
-                        {
-                            ModList.Add(tMod);
-                            Found = true;
-                        }
-
-                    if (!Found)
-                    {
-                        //error out
-                        MessageBox.Show("A mod vanished!", "HoN_ModMan", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                        myStatusLabel.Text = m_mods.Count + " mods loaded.";
-                        return false;
-                    }
-                }
-            }
+            var ModList = m_mods.Where(x => x.Enabled).ToList();
 
             var i = 0;
             while (i < ModList.Count)


### PR DESCRIPTION
Basically, if any mods were selected(highlighted) then enabled/disabled logic was ignored.
Made it so only enabled/disabled mods are taken into account when applying - ignoring what is selected/highlighted.

For whatever reason, a package required in the .csproj file wasn't playing ball and prevented me from building... Doesn't seem to have had any issues when removing it - so maybe it was redundant?
